### PR TITLE
Generator: do not lock huginn_agent version in gemspec

### DIFF
--- a/lib/huginn_agent/cli.rb
+++ b/lib/huginn_agent/cli.rb
@@ -1,4 +1,5 @@
 require 'thor'
+require 'huginn_agent/version'
 
 class HuginnAgent
   class CLI < Thor

--- a/lib/huginn_agent/templates/newagent/Gemfile.tt
+++ b/lib/huginn_agent/templates/newagent/Gemfile.tt
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'huginn_agent', "~> 0.3.0"
+gem 'huginn_agent', '~> <%= HuginnAgent::VERSION %>'

--- a/lib/huginn_agent/templates/newagent/newagent.gemspec.tt
+++ b/lib/huginn_agent/templates/newagent/newagent.gemspec.tt
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency "huginn_agent", '~> 0.2'
+  spec.add_runtime_dependency "huginn_agent"
 end


### PR DESCRIPTION
The huginn_agent version in agent gems should not be locked in the gemspec per default, Huginn already has the version locked in its Gemfile. As long as the Agent gem does not require a specific huginn_agent gem version it should not care about it.
For the development of the Agent gem we specify the huginn_agent gem version in the Gemfile.