### PR TITLE
Run agent gem specs in spec subdirectories

### DIFF
--- a/lib/huginn_agent/spec_runner.rb
+++ b/lib/huginn_agent/spec_runner.rb
@@ -39,7 +39,7 @@ class HuginnAgent
 
     def spec
       Dir.chdir('spec/huginn') do
-        shell_out "bundle exec rspec ../*.rb", 'Running specs ...', true
+        shell_out "bundle exec rspec ../*_spec.rb ../**/*_spec.rb", 'Running specs ...', true
       end
     end
 


### PR DESCRIPTION
Now runs only files ending with `_spec.rb` to allow adding spec support files which should no be executed by rspec.

Fixes #4