### PR TITLE
Fix rspec pattern

### DIFF
--- a/lib/huginn_agent/spec_runner.rb
+++ b/lib/huginn_agent/spec_runner.rb
@@ -39,7 +39,7 @@ class HuginnAgent
 
     def spec
       Dir.chdir('spec/huginn') do
-        shell_out "bundle exec rspec ../*_spec.rb ../**/*_spec.rb", 'Running specs ...', true
+        shell_out "bundle exec rspec --pattern ../*_spec.rb,../{[!huginn/]}**/*_spec.rb", 'Running specs ...', true
       end
     end
 


### PR DESCRIPTION
Fixes specs for Agent gems that do not use subdirectories inside the spec directory
Prevents running of the whole Huginn spec suite