### PR TITLE
Adapt template to use ruby >= 2.2.2 on Travis

### DIFF
--- a/lib/huginn_agent/templates/newagent/travis.yml.tt
+++ b/lib/huginn_agent/templates/newagent/travis.yml.tt
@@ -7,8 +7,7 @@ env:
     - DATABASE_ADAPTER=mysql2
     - DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
 rvm:
-- 2.1
-- 2.2
+- 2.2.2
 - 2.3.0
 cache: bundler
 script: bundle exec rake


### PR DESCRIPTION
The current template configures Travis to do matrix test with rvm 2.1, 2.2 and 2.3.0. However Huginn requires ruby >= 2.2.2 (meanwhile).

Hence testing on rvm 2.1 fail for obvious reasons.  Travis in sudo-less environment uses ruby 2.2.0 (for rvm 2.2) and hence spec test also fails.

This patch removes 2.1 matrix axis completely and makes Travis use 2.2.2 instead of 2.2.0