### PR TITLE
exclude spec/huginn/ subtree from test_files

### DIFF
--- a/lib/huginn_agent/templates/newagent/newagent.gemspec.tt
+++ b/lib/huginn_agent/templates/newagent/newagent.gemspec.tt
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['LICENSE.txt', 'lib/**/*']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = Dir['spec/**/*.rb']
+  spec.test_files    = Dir['spec/**/*.rb'].reject { |f| f[%r{^spec/huginn}] }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
`gem build` obviously shouldn't include the spec/huginn/ subtree :-)

... this excludes it once and for all (so you don't have to manually `rm -rf` or move it away each time)