### PR TITLE
Use `system` to run Agent gem specs

### DIFF
--- a/lib/huginn_agent/helper.rb
+++ b/lib/huginn_agent/helper.rb
@@ -2,24 +2,26 @@ require 'open3'
 
 class HuginnAgent
   class Helper
-    def self.open3(command, streaming_output = true)
+    def self.open3(command)
       output = ""
-      print "\n" if streaming_output
 
       status = Open3.popen3(ENV, "#{command} 2>&1") do |stdin, stdout, _stderr, wait_thr|
         stdin.close
 
         until stdout.eof do
           next unless IO.select([stdout])
-          data = stdout.read_nonblock(1024)
-          print data if streaming_output
-          output << data
+          output << stdout.read_nonblock(1024)
         end
         wait_thr.value
       end
       [status.exitstatus, output]
     rescue IOError => e
       return [1, "#{e} #{e.message}"]
+    end
+
+    def self.exec(command)
+      print "\n"
+      [system(ENV, command) == true ? 0 : 1, '']
     end
   end
 end

--- a/lib/huginn_agent/spec_runner.rb
+++ b/lib/huginn_agent/spec_runner.rb
@@ -49,7 +49,11 @@ class HuginnAgent
       (status, output) = Bundler.with_clean_env do
         ENV['ADDITIONAL_GEMS'] = "#{gem_name}(path: ../../)"
         ENV['RAILS_ENV'] = 'test'
-        HuginnAgent::Helper.open3(command, streaming_output)
+        if streaming_output
+          HuginnAgent::Helper.exec(command)
+        else
+          HuginnAgent::Helper.open3(command)
+        end
       end
 
       if status == 0

--- a/spec/lib/huginn_agent/helper_spec.rb
+++ b/spec/lib/huginn_agent/helper_spec.rb
@@ -4,28 +4,34 @@ describe HuginnAgent::Helper do
   context '#open3' do
     it "returns the exit status and output of the command" do
       expect(HuginnAgent::Helper).not_to receive(:print)
-      (status, output) = HuginnAgent::Helper.open3("pwd", false)
-      expect(status).to eq(0)
-      expect(output).to eq("#{Dir.pwd}\n")
-    end
-
-    it "prints the output directly when specified" do
-      expect(HuginnAgent::Helper).to receive(:print).twice
-      (status, output) = HuginnAgent::Helper.open3("pwd", true)
+      (status, output) = HuginnAgent::Helper.open3("pwd")
       expect(status).to eq(0)
       expect(output).to eq("#{Dir.pwd}\n")
     end
 
     it "return 1 as the status for failing command" do
-      (status, output) = HuginnAgent::Helper.open3("false", false)
+      (status, output) = HuginnAgent::Helper.open3("false")
       expect(status).to eq(1)
     end
 
     it "returns 1 when an IOError occurred" do
       expect(IO).to receive(:select).and_raise(IOError)
-      (status, output) = HuginnAgent::Helper.open3("pwd", false)
+      (status, output) = HuginnAgent::Helper.open3("pwd")
       expect(status).to eq(1)
       expect(output).to eq('IOError IOError')
+    end
+  end
+
+  context '#exec' do
+    it "returns the exit status and output of the command" do
+      (status, output) = HuginnAgent::Helper.exec("pwd")
+      expect(status).to eq(0)
+      expect(output).to eq('')
+    end
+
+    it "return 1 as the status for failing command" do
+      (status, output) = HuginnAgent::Helper.exec("false")
+      expect(status).to eq(1)
     end
   end
 end


### PR DESCRIPTION
This allows the usage of gems like `pry` when running the specs.